### PR TITLE
Print the error message for failed file opens

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -188,18 +188,19 @@ namespace RawFileReaderDotNetExample
 
                 if (!rawFile.IsOpen || rawFile.IsError)
                 {
+                    // Check for any errors in the RAW file
+                    if (rawFile.IsError)
+                    {
+                        Console.WriteLine("Error opening ({0}) - {1}", rawFile.FileError.ErrorMessage, filename);
+
+                        return;
+                    }
+
                     Console.WriteLine("Unable to access the RAW file using the RawFileReader class!");
-                    
-                    return;
-                }
-
-                // Check for any errors in the RAW file
-                if (rawFile.IsError)
-                {
-                    Console.WriteLine("Error opening ({0}) - {1}", rawFile.FileError, filename);
 
                     return;
                 }
+
 
                 // Check if the RAW file is being acquired
                 if (rawFile.InAcquisition)


### PR DESCRIPTION
Currently whenever there is an error only "Unable to access the RAW file using the RawFileReader class!" is printed but no more details.

This changes the example in a way to print the full error if something goes wrong to open the file.